### PR TITLE
Upgrade react-minimalist-portal to support SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/bsidelinger912/react-tooltip-lite#readme",
   "dependencies": {
     "prop-types": "^15.5.8",
-    "react-minimalist-portal": "^2.1.1"
+    "react-minimalist-portal": "^2.2.0"
   },
   "peerDependencies": {
     "react": "^15.5.4 || ^16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3227,9 +3227,9 @@ react-hot-loader@^1.3.1:
     react-hot-api "^0.4.5"
     source-map "^0.4.4"
 
-react-minimalist-portal@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/react-minimalist-portal/-/react-minimalist-portal-2.1.1.tgz#d32c403f446c5cb91060e3a3c70beba8c3d08c8f"
+react-minimalist-portal@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-minimalist-portal/-/react-minimalist-portal-2.2.0.tgz#fad17a374d55ce16c0b0bdafce3672776043d78f"
   dependencies:
     prop-types "^15.6.0"
 


### PR DESCRIPTION
Hi. `react-minimalist-portal` was recently updated to [support SSR](https://github.com/pradel/react-minimalist-portal/releases/tag/v2.2.0). This PR updates its version.