### PR TITLE
Pass along props

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -128,6 +128,7 @@ class Tooltip extends React.Component {
       arrow,
       arrowSize,
       distance,
+      ...others,
     } = this.props;
 
     const showTip = (typeof isOpen === 'undefined') ? this.state.showTip : isOpen;
@@ -199,7 +200,7 @@ class Tooltip extends React.Component {
     }
 
     return (
-      <this.props.tagName {...props}>
+      <this.props.tagName {...others} {...props}>
         {children}
 
         <Portal>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -128,8 +128,10 @@ class Tooltip extends React.Component {
       arrow,
       arrowSize,
       distance,
-      ...others,
+      tagName: TagName,
+      ...others
     } = this.props;
+    delete others.hoverDelay;
 
     const showTip = (typeof isOpen === 'undefined') ? this.state.showTip : isOpen;
     const currentPositions = positions(direction, this.tip, this.target, { ...this.state, showTip }, {
@@ -200,7 +202,7 @@ class Tooltip extends React.Component {
     }
 
     return (
-      <this.props.tagName {...others} {...props}>
+      <TagName {...others} {...props}>
         {children}
 
         <Portal>
@@ -211,7 +213,7 @@ class Tooltip extends React.Component {
             <span className={`react-tooltip-lite-arrow react-tooltip-lite-${currentPositions.realDirection}-arrow`} style={arrowStyles} />
           </div>
         </Portal>
-      </this.props.tagName>
+      </TagName>
     );
   }
 }


### PR DESCRIPTION
Hey,

We started using your library today. It's exactly what I've been looking for for a long time! Thanks 😄 

We made some changes we either need or want for [our project](https://github.com/WoWAnalyzer/WoWAnalyzer). We're using a fork now so there's both no haste nor any need to have these changes merged in, but hopefully it will help.

For this first PR I'd like to propose passing along all properties. In combination with the pre-existing `tagName` prop, this makes it possible to do things like:

```jsx
<Tooltip content="Search with Google" tagName="a" href="https://google.com">Search</Tooltip>
```