### PR TITLE
Split className into a separate prop for the element and the tooltip

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -20,6 +20,7 @@ class Tooltip extends React.Component {
     tagName: PropTypes.string,
     direction: PropTypes.string,
     className: PropTypes.string,
+    tooltipClassName: PropTypes.string,
     content: PropTypes.node.isRequired,
     background: PropTypes.string,
     color: PropTypes.string,
@@ -36,12 +37,12 @@ class Tooltip extends React.Component {
     arrow: PropTypes.bool,
     arrowSize: PropTypes.number,
     distance: PropTypes.number,
-  }
-
+  };
   static defaultProps = {
     tagName: 'div',
     direction: 'up',
     className: '',
+    tooltipClassName: '',
     background: '',
     color: '',
     padding: '10px',
@@ -53,7 +54,7 @@ class Tooltip extends React.Component {
     arrow: true,
     arrowSize: 10,
     distance: undefined,
-  }
+  };
 
   constructor() {
     super();
@@ -112,6 +113,7 @@ class Tooltip extends React.Component {
     const {
       direction,
       className,
+      tooltipClassName,
       padding,
       children,
       content,
@@ -203,7 +205,7 @@ class Tooltip extends React.Component {
         {children}
 
         <Portal>
-          <div {...portalProps} className={className}>
+          <div {...portalProps} className={tooltipClassName}>
             <span className="react-tooltip-lite" style={tipStyles} ref={(tip) => { this.tip = tip; }}>
               {content}
             </span>


### PR DESCRIPTION
Right now if you set the `className`, it will apply it to both the element and the tooltip. This change makes it possible to control them separate. I chose this naming as passing DOM props to the original element will be standard with #29, so having `className` behave as it always does seems to make the most sense.

Note: this is a breaking change. Anyone relying on `className` to be applied to tooltips may be affected.