### PR TITLE
Clear hover timeout on unmount

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -126,6 +126,7 @@ class Tooltip extends React.Component {
     window.removeEventListener('resize', this.listenResizeScroll);
     window.removeEventListener('scroll', this.listenResizeScroll);
     clearTimeout(this.debounceTimeout);
+    clearTimeout(this.hoverTimeout);
   }
 
   listenResizeScroll() {


### PR DESCRIPTION
The hover timeout is never cleared on unmount.

We have some components, with tooltips, that can mount/unmount quickly depending on user action. Because of the hover timeout we often get react warnings in the console (setState on unmounted component).

With this addition the warnings are gone.