### PR TITLE
Allow user to override zIndex

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -42,6 +42,7 @@ class Tooltip extends React.Component {
     tipContentClassName: PropTypes.string,
     useDefaultStyles: PropTypes.bool,
     useHover: PropTypes.bool,
+    zIndex: PropTypes.number
   }
 
   static defaultProps = {
@@ -66,6 +67,7 @@ class Tooltip extends React.Component {
     tipContentClassName: undefined,
     useDefaultStyles: false,
     useHover: true,
+    zIndex: 1000
   }
 
   static getDerivedStateFromProps(nextProps) {
@@ -270,7 +272,7 @@ class Tooltip extends React.Component {
         color: useDefaultStyles ? defaultColor : color,
         padding,
         boxSizing: 'border-box',
-        zIndex: 1000,
+        zIndex: this.props.zIndex,
         position: 'absolute',
         display: 'inline-block',
       };
@@ -280,7 +282,7 @@ class Tooltip extends React.Component {
         position: 'absolute',
         width: '0px',
         height: '0px',
-        zIndex: 1001,
+        zIndex: this.props.zIndex + 1,
       };
 
       tipPortal = (


### PR DESCRIPTION
In some cases the zIndex isn't high enough. e.g. When trying to get a tooltip to show on a bootstrap nav button. This will allow the user to override it.

`<Tooltip direction="bottom" content="This is a tooltip" zIndex={1050}>Content</Tooltip>`