### PR TITLE
Add hideOnScroll option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ You can pass in props to define tip direction, styling, etc.  Content is the onl
       <td>forces open/close state from a prop, overrides hover or click state</td>
     </tr>
     <tr>
+      <td>hideOnScroll</td>
+      <td>boolean</td>
+      <td>whether to hide the tip on window scroll, defaults to false</td>
+    </tr>
+    <tr>
       <td>hoverDelay</td>
       <td>number</td>
       <td>the number of milliseconds to determine hover intent, defaults to 200</td>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -32,6 +32,7 @@ class Tooltip extends React.Component {
     eventOn: PropTypes.string,
     eventToggle: PropTypes.string,
     forceDirection: PropTypes.bool,
+    hideOnScroll: PropTypes.bool,
     hoverDelay: PropTypes.number,
     isOpen: PropTypes.bool,
     mouseOutDelay: PropTypes.number,
@@ -56,6 +57,7 @@ class Tooltip extends React.Component {
     eventOn: undefined,
     eventToggle: undefined,
     forceDirection: false,
+    hideOnScroll: false,
     hoverDelay: 200,
     isOpen: undefined,
     mouseOutDelay: undefined,
@@ -133,16 +135,19 @@ class Tooltip extends React.Component {
 
   listenResizeScroll() {
     clearTimeout(this.debounceTimeout);
-
     this.debounceTimeout = setTimeout(this.handleResizeScroll, resizeThrottle);
   }
 
   handleResizeScroll() {
-    if (this.state.showTip) {
-      // if we're showing the tip and the resize was actually a signifigant change, then setState to re-render and calculate position
-      const clientWidth = Math.round(document.documentElement.clientWidth / resizeThreshold) * resizeThreshold;
-      this.setState({ clientWidth });
+    if (!this.state.showTip) return;
+    
+    if (this.props.hideOnScroll) {
+      this.hideTip();
     }
+
+    // if we're showing the tip and the resize was actually a signifigant change, then setState to re-render and calculate position
+    const clientWidth = Math.round(document.documentElement.clientWidth / resizeThreshold) * resizeThreshold;
+    this.setState({ clientWidth });
   }
 
   toggleTip() {


### PR DESCRIPTION
This option forces the tooltip to close on window scroll.

I created it as a workaround to https://github.com/bsidelinger912/react-tooltip-lite/issues/59