### PR TITLE
add show and hide class

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -349,10 +349,10 @@ class Tooltip extends React.Component {
       tipPortal = (
         <Portal>
           <div {...portalProps} className={typeof tipContentClassName !== 'undefined' ? tipContentClassName : className}>
-            <span className="react-tooltip-lite" style={tipStyles} ref={(tip) => { this.tip = tip; }}>
+            <span className={`react-tooltip-lite ${showTip ? 'show' : 'hide'}`} style={tipStyles} ref={(tip) => { this.tip = tip; }}>
               {content}
             </span>
-            <span className={`react-tooltip-lite-arrow react-tooltip-lite-${currentPositions.realDirection}-arrow`} style={arrowStyles}>{arrowContent}</span>
+            <span className={`react-tooltip-lite-arrow react-tooltip-lite-${currentPositions.realDirection}-arrow ${showTip ? 'show' : 'hide'}`} style={arrowStyles}>{arrowContent}</span>
           </div>
         </Portal>
       );


### PR DESCRIPTION
Hello,

I'm creating this pull request to add a "show" or "hide" class to the tooltip.
Indeed, this allows us to be able to apply display transitions such as opacity.

Thanks in advance,
Valentin.